### PR TITLE
Update visao_estereo.py

### DIFF
--- a/Visao_Estereo/OLD_StereoMatcher
+++ b/Visao_Estereo/OLD_StereoMatcher
@@ -1,0 +1,90 @@
+# Autores: Matheus Teixeira de Sousa (teixeira.sousa@aluno.unb.br)
+#          João Luiz Machado Júnior (180137158@aluno.unb.br)
+# Disciplina: Princípios de Visão Computacional - turma A
+
+import cv2 as cv
+import numpy as np
+import matplotlib.pyplot as plt
+import re
+
+def data_reader(file_name):
+# Função para leitura de dados de calibração em arquivo .txt
+
+    lines = []
+    data = []
+
+    with open(file_name) as f:
+        lines = f.readlines() # Armazenar linhas do arquivo em lista
+
+    for i in range(len(lines)): data.append(re.findall(r"[-+]?\d*\.\d+|\d+", lines[i]))
+    # Coleta linha-a-linha de números relevantes na lista
+
+    del data[0][0]; # Remoção dos números irrelevantes que identificam o nome de cada câmera
+    del data[1][0];
+
+    return data
+
+def disparity_calculator(left_image, right_image, disparities_num):
+
+	window_size = 3
+
+	left_matcher = cv.StereoSGBM_create(
+	    minDisparity=16,
+	    numDisparities= disparities_num,  # Definido como 640 antes da chamada da função)
+	    blockSize=window_size,
+	    P1=8 * 3 * window_size,
+	    P2=32 * 3 * window_size,
+	    disp12MaxDiff=12,
+	    uniquenessRatio=10,
+	    speckleWindowSize=50,
+	    speckleRange=32,
+	    preFilterCap=63,
+	    mode=cv.STEREO_SGBM_MODE_SGBM_3WAY
+	)
+	right_matcher = cv.ximgproc.createRightMatcher(left_matcher)
+
+	# parâmetros do filtro
+	lmbda = 80000
+	sigma = 1.3
+	visual_multiplier = 6
+
+	wls_filter = cv.ximgproc.createDisparityWLSFilter(matcher_left=left_matcher)
+	wls_filter.setLambda(lmbda)
+
+	wls_filter.setSigmaColor(sigma)
+	displ = left_matcher.compute(left_image, right_image) 
+	dispr = right_matcher.compute(right_image, left_image)
+	displ = np.int16(displ)
+	dispr = np.int16(dispr)
+	filteredImg = wls_filter.filter(displ, left_image, None, dispr)
+
+	# Normaliza o filtro
+	filteredImg = cv.normalize(src=filteredImg, dst=filteredImg, beta=0, alpha=255, norm_type=cv.NORM_MINMAX)
+	filteredImg = np.uint8(filteredImg)
+
+	return filteredImg
+
+# -------------------------------------------------------------------------------
+
+calib_jade_data = []
+calib_table_data = []
+
+imgL = cv.imread('jadeL.png', cv.COLOR_BGR2GRAY)
+imgR = cv.imread('jadeR.png', cv.COLOR_BGR2GRAY)
+disparities_num = 640
+
+filteredImg = disparity_calculator(imgL, imgR, disparities_num)
+
+# cv.imshow('filtered', filteredImg) Corrigir o tamanho da janela de exibição
+cv.imwrite('filtered.jpg', filteredImg)
+
+# Mostra imagem de disparidades com mapa de cores, padrão "jet"
+plt.imshow(filteredImg, cmap='jet')
+plt.colorbar()
+plt.savefig("color_filtered.jpg")
+plt.show()
+
+cv.waitKey(0)
+
+calib_jade_data = data_reader('calib_jade.txt')
+calib_table_data = data_reader('calib_table.txt')

--- a/Visao_Estereo/eval.py
+++ b/Visao_Estereo/eval.py
@@ -1,0 +1,83 @@
+import cv2 as cv
+import numpy as np
+
+def evaldisp(disparity, gtdisp, badthresh, maxdisp, rounddisp):
+
+	gt_shape = gtdisp.shape
+	disp_shape = disparity.shape
+
+	width = gt_shape[0]
+	height = gt_shape[1]
+	width2 = disp_shape[0]
+	height2 = disp_shape[1]
+	scale = width / width2
+
+	if ((scale != 1 and scale != 2 and scale != 4)
+	or ((scale * width2) != width)
+	or ((scale * height2) != height)):
+		print("	  disp size = ", width2, " x ", height2)
+		print("GT disp size =", width, " x ", height)
+		raise ValueError("GT disp size must be exactly 1, 2, or 4 * disp size");
+
+	n = 0
+	bad = 0
+	invalid = 0
+	serr = 0.0
+	print(disparity)
+	print(gtdisp)
+	for y in range(height):
+		for x in range(width):
+			gt = gtdisp[x, y]
+
+			if (gt == np.inf):
+				continue
+
+			d = float(scale * disparity[int(x/scale), int(y/scale)])
+			valid = (d != np.inf)
+
+			if (valid):
+				maxd = scale * maxdisp
+				d = max(0, min(maxd, d))
+				
+			if (valid and rounddisp):
+				d = round(d)
+
+			err = abs(d-gt)
+			n += 1
+
+			if (valid):
+				serr += err
+				if (err > badthresh):
+					bad += 1
+					pass
+				pass
+			pass
+		pass
+
+	badpercent =  100.0*bad/n
+	invalidpercent =  100.0*invalid/n
+	totalbadpercent =  100.0*(bad+invalid)/n
+	avgErr = serr / (n - invalid)
+
+	print(100.0*n/(width*height), "Bad percentage: ", badpercent, "Invalid percentage: ", invalidpercent, "Total bad percentage: ", totalbadpercent, "Average error: ", avgErr)
+
+	pass
+
+disparity = cv.imread('disparidade.pgm', cv.IMREAD_GRAYSCALE)
+gtdisp = cv.imread('disp0-n.pgm', cv.IMREAD_GRAYSCALE)
+
+cv.namedWindow('Disparidade calculada', cv.WINDOW_NORMAL)
+cv.resizeWindow('Disparidade calculada', (439, 331))
+cv.imshow('Disparidade calculada', disparity)
+
+cv.namedWindow('GroundTruth disponibilizado', cv.WINDOW_NORMAL)
+cv.resizeWindow('GroundTruth disponibilizado', (439, 331))
+cv.imshow('GroundTruth disponibilizado', gtdisp)
+
+cv.waitKey(0)
+
+badthresh = 2
+maxdisp = 1988 / 3
+rounddisp = 0
+
+evaldisp(disparity, gtdisp, badthresh, maxdisp, rounddisp)

--- a/Visao_Estereo/evaldisp.cpp
+++ b/Visao_Estereo/evaldisp.cpp
@@ -1,0 +1,129 @@
+// evaldisp.cpp 
+
+// evaluate disparity map
+// simple version for SDK
+// supports upsampling of disp map if GT has higher resolution
+
+// DS 7/2/2014
+// 10/14/2014 changed computation of average error
+// 1/27/2015 added clipping of valid (non-INF) disparities to [0 .. maxdisp]
+//    in fairness to those methods that do not utilize the given disparity range
+//    (maxdisp is specified at disp resolution, NOT GT resolution)
+
+static const char *usage = "\n  usage: %s disp.pfm gtdisp.pfm badthresh maxdisp rounddisp [mask.png]\n\
+    (or call with single argument badthresh to print column headers)\n";
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <vector>
+#include "imageLib.h"
+
+int verbose = 0;
+
+void evaldisp(CFloatImage disp, CFloatImage gtdisp, CByteImage mask, float badthresh, int maxdisp, int rounddisp)
+{
+    CShape sh = gtdisp.Shape();
+    CShape sh2 = disp.Shape();
+    CShape msh = mask.Shape();
+    int width = sh.width, height = sh.height;
+    int width2 = sh2.width, height2 = sh2.height;
+    int scale = width / width2;
+
+    if ((!(scale == 1 || scale == 2 || scale == 4))
+	|| (scale * width2 != width)
+	|| (scale * height2 != height)) {
+	printf("disp size = %4d x %4d\n", width2, height2);
+	printf("GT disp size = %4d x %4d\n", width,  height);
+	throw CError("GT disp size must be exactly 1, 2, or 4 * disp size");
+    }
+
+    int usemask = (msh.width > 0 && msh.height > 0);
+    if (usemask && (msh != sh))
+	throw CError("mask image must have same size as GT\n");
+
+    int n = 0;
+    int bad = 0;
+    int invalid = 0;
+    float serr = 0;
+    for (int y = 0; y < height; y++) {
+	for (int x = 0; x < width; x++) {
+	    float gt = gtdisp.Pixel(x, y, 0);
+	    if (gt == INFINITY) // unknown
+		continue;
+	    float d = scale * disp.Pixel(x / scale, y / scale, 0);
+	    int valid = (d != INFINITY);
+	    if (valid) {
+		float maxd = scale * maxdisp; // max disp range
+		d = __max(0, __min(maxd, d)); // clip disps to max disp range
+	    }
+	    if (valid && rounddisp)
+		d = round(d);
+	    float err = fabs(d - gt);
+	    if (usemask && mask.Pixel(x, y, 0) != 255) { // don't evaluate pixel
+	    } else {
+		n++;
+		if (valid) {
+		    serr += err;
+		    if (err > badthresh) {
+			bad++;
+		    }
+		} else {// invalid (i.e. hole in sparse disp map)
+		    invalid++;
+		}
+	    }
+	}
+    }
+    float badpercent =  100.0*bad/n;
+    float invalidpercent =  100.0*invalid/n;
+    float totalbadpercent =  100.0*(bad+invalid)/n;
+    float avgErr = serr / (n - invalid); // CHANGED 10/14/2014 -- was: serr / n
+    //printf("mask  bad%.1f  invalid  totbad   avgErr\n", badthresh);
+    printf("%4.1f  %6.2f  %6.2f   %6.2f  %6.2f\n",   100.0*n/(width * height), 
+	   badpercent, invalidpercent, totalbadpercent, avgErr);
+}
+
+int main(int argc, char *argv[])
+{
+    try {
+	int requiredargs = 3;
+	int optionalargs = 3;
+	if (argc >= requiredargs + 1 && argc <= requiredargs + optionalargs + 1) {
+	    int argn = 1;
+	    char *dispname = argv[argn++];
+	    char *gtdispname = argv[argn++];
+	    float badthresh = atof(argv[argn++]);
+	    int maxdisp = 99999;
+	    if (argc > argn)
+		maxdisp = atoi(argv[argn++]);
+	    int rounddisp = 0;
+	    if (argc > argn)
+		rounddisp = atoi(argv[argn++]);
+	    char *maskname = NULL;
+	    if (argc > argn)
+		maskname = argv[argn++];
+      
+	    CFloatImage disp, gtdisp, gtdisp1;
+	    ReadImageVerb(disp, dispname, verbose);
+	    ReadImageVerb(gtdisp, gtdispname, verbose);
+	    CByteImage mask;
+	    if (maskname)
+		ReadImageVerb(mask, maskname, verbose);
+
+	    evaldisp(disp, gtdisp, mask, badthresh, maxdisp, rounddisp);
+
+	} else if (argc == 2) {
+	    float badthresh = atof(argv[1]);
+	    // show what the header looks like (can grep in scripts)
+	    printf("mask  bad%.1f  invalid  totbad   avgErr\n", badthresh);
+	} else
+	    throw CError(usage, argv[0]);
+    }
+    catch (CError &err) {
+	fprintf(stderr, err.message);
+	fprintf(stderr, "\n");
+	return -1;
+    }
+  
+    return 0;
+}

--- a/Visao_Estereo/src/functions.py
+++ b/Visao_Estereo/src/functions.py
@@ -52,14 +52,11 @@ def image_depth (img, calib_data, save_dir):
 
 	f = float(calib_data[0][0])
 	bline = float(calib_data[3][0])
-	# doff = float(calib_data[2][0])
-	# scale = 0.03922 # Era 0.003922, mas eu mudei para 0.03922 e ficou melhor (???)
 	aux = np.zeros(img.shape)
 	img_float = aux + img
 	new_diff = img_float - aux
 	new_diff[new_diff == 0.0] = np.inf
 	
-	# Z = bline * f / (img/scale + doff)
 	Z = bline * f / new_diff
 	filtered_depth_image = cv.normalize(src=Z, dst=Z, beta=0, alpha=254, norm_type=cv.NORM_MINMAX)
 	filtered_depth_image = np.uint8(filtered_depth_image)
@@ -77,17 +74,17 @@ def image_depth (img, calib_data, save_dir):
 	# por um simples ajuste de escala:
 	# original = np.array((filtered_depth_image - minimo) / float(maximo))
 
-def disparity_calculator(left_image, right_image, disparities_num, min_num):
+def disparity_calculator(left_image, right_image, min_num, max_num):
 # Função que calcula mapa de disparidades dadas duas imagens estereo-retificadas
 
 	window_size = 3
 
 	left_matcher = cv.StereoSGBM_create(
 	    minDisparity = min_num,
-	    numDisparities = disparities_num,  # Numero maximo de disparidades
+	    numDisparities = 16*(max_num//16), # Numero maximo de disparidades
 	    blockSize = window_size,
-	    P1 = 8*3*window_size,
-	    P2 = 32*3*window_size,
+	    P1 = 8*3*window_size**2,
+	    P2 = 32*3*window_size**2,
 	    disp12MaxDiff = 12,
 	    uniquenessRatio = 10,
 	    speckleWindowSize = 50,

--- a/Visao_Estereo/src/visao_estereo.py
+++ b/Visao_Estereo/src/visao_estereo.py
@@ -22,17 +22,17 @@ def first_requirement():
 
 	for i in [0,1]:
 		print('\nLoading images from ' + name[i] + ' data base...', flush=True)
-		imgL = cv.imread(os.path.join(data[i], images[0]), cv.COLOR_BGR2GRAY)
-		imgR = cv.imread(os.path.join(data[i], images[1]), cv.COLOR_BGR2GRAY)
+		imgL = cv.imread(os.path.join(data[i], images[0]), cv.IMREAD_GRAYSCALE)
+		imgR = cv.imread(os.path.join(data[i], images[1]), cv.IMREAD_GRAYSCALE)
 
 		calib_data = f.data_reader(os.path.join(data[i], 'calib.txt'))
 
 		min_disp = int(calib_data[8][0])
 		max_disp = int(calib_data[9][0])
-		
+
 		print('Calculating disparity map...', flush=True)
 		filteredImg = f.disparity_calculator(imgL, imgR, min_disp, max_disp)
-
+		
 		# Redimensiona a imagem para uma melhor visualização
 		cv.namedWindow('filtered', cv.WINDOW_NORMAL)
 		cv.resizeWindow('filtered', (439, 331))
@@ -43,12 +43,17 @@ def first_requirement():
 		cv.waitKey(0)
 		cv.destroyAllWindows()
 		cv.imwrite(os.path.join(data[i],'disparidade.pgm'), filteredImg)
-
+		
 		# Mostra imagem de disparidades com mapa de cores, padrão "jet"
-		# plt.imshow(filteredImg, cmap='jet')
-		# plt.colorbar()
+		plt.imshow(filteredImg, cmap='jet')
+		plt.colorbar()
 		# plt.savefig(os.path.join(data[i], 'color_filtered.jpg'))
-		# plt.show()
+		plt.show()
+
+		disp_max =  (float(calib_data[5][0]) / 3)
+		gt = cv.imread(os.path.join(data[i], 'disp0-n.pgm'), cv.IMREAD_GRAYSCALE)
+		deu_certo = f.taxa_erro(filteredImg, gt, disp_max)
+		print('Taxa de pixels ruins: {:.2f}%'.format(deu_certo*100.0))
 
 		print('Calculating depth map...', flush=True)
 		f.image_depth(filteredImg, calib_data, os.path.join(data[i],'profundidade.png'))
@@ -73,7 +78,7 @@ if __name__ == "__main__":
 	requirement = ['1', '2', '3']
 
 	while data not in requirement: 
-		print('\n\nThere is not requiremente number ' + data)
+		print('\n\nError! There is no requirement number ' + data)
 		data = input('Define the number of requirement (1, 2, 3): ')
 	if data == '1':
 		first_requirement()
@@ -81,3 +86,4 @@ if __name__ == "__main__":
 		second_requirement()
 	elif data == '3':
 		third_requirement()
+		

--- a/Visao_Estereo/src/visao_estereo.py
+++ b/Visao_Estereo/src/visao_estereo.py
@@ -50,7 +50,9 @@ def first_requirement():
 		# plt.savefig(os.path.join(data[i], 'color_filtered.jpg'))
 		plt.show()
 
-		disp_max =  (float(calib_data[5][0]) / 3)
+		# O valor máximo de disparidade pode ser retirado do arquivo de dados de calibração
+		# ou aproximado como um terço da altura da imagem : (float(calib_data[5][0]) / 3)
+		disp_max =  float(calib_data[9][0])
 		gt = cv.imread(os.path.join(data[i], 'disp0-n.pgm'), cv.IMREAD_GRAYSCALE)
 		deu_certo = f.taxa_erro(filteredImg, gt, disp_max)
 		print('Taxa de pixels ruins: {:.2f}%'.format(deu_certo*100.0))

--- a/Visao_Estereo/src/visao_estereo.py
+++ b/Visao_Estereo/src/visao_estereo.py
@@ -26,13 +26,12 @@ def first_requirement():
 		imgR = cv.imread(os.path.join(data[i], images[1]), cv.COLOR_BGR2GRAY)
 
 		calib_data = f.data_reader(os.path.join(data[i], 'calib.txt'))
-		#calib_table_data = f.data_reader(os.path.join(data[1], 'calib.txt'))
 
-		disparities_num = int(calib_data[9][0])
 		min_disp = int(calib_data[8][0])
+		max_disp = int(calib_data[9][0])
 		
 		print('Calculating disparity map...', flush=True)
-		filteredImg = f.disparity_calculator(imgL, imgR, disparities_num, min_disp)
+		filteredImg = f.disparity_calculator(imgL, imgR, min_disp, max_disp)
 
 		# Redimensiona a imagem para uma melhor visualização
 		cv.namedWindow('filtered', cv.WINDOW_NORMAL)
@@ -43,7 +42,7 @@ def first_requirement():
 		cv.imshow('filtered', filteredImg)
 		cv.waitKey(0)
 		cv.destroyAllWindows()
-		cv.imwrite(os.path.join(data[i],'filtered.jpg'), filteredImg)
+		cv.imwrite(os.path.join(data[i],'disparidade.pgm'), filteredImg)
 
 		# Mostra imagem de disparidades com mapa de cores, padrão "jet"
 		# plt.imshow(filteredImg, cmap='jet')
@@ -52,7 +51,7 @@ def first_requirement():
 		# plt.show()
 
 		print('Calculating depth map...', flush=True)
-		f.image_depth(filteredImg, calib_data, os.path.join(data[i],'DepthMap.jpg'))
+		f.image_depth(filteredImg, calib_data, os.path.join(data[i],'profundidade.png'))
 
 def second_requirement():
 	# Define o diretório anterior ao diretório do programa


### PR DESCRIPTION
Código principal modificado na parte do requerimento 1: agora produzindo apenas a disparidade em formato pgm e a profundidade em preto e branco, em png. Também foi removido um comentário antigo na linha 28 que era só a inicialização da variável com os dados de calibração, algo que agora já é feito pelo f.data_reader com a pesquisa de diretório criada pelo Matheus. Por fim, eu também troquei a ordem da coleta de dados e mudei o nome das duas variáveis que são passadas como argumentos pro disparity_calculator, pra ser na ordem crescente de linhas lidas do arquivo txt.